### PR TITLE
[SDK 179] Fix result type of GetWallets query

### DIFF
--- a/enjin/schemas/project/query/GetWallets.gql
+++ b/enjin/schemas/project/query/GetWallets.gql
@@ -1,20 +1,14 @@
 #namespace enjin.sdk.project.GetWallets
 #import enjin.sdk.shared.Wallet
-#import enjin.sdk.shared.PaginationCursor
 
 #arg userIds [String]
 #arg ethAddresses [EthAddress]
 
 query {
-    results: GetWallets(
+    result: GetWallets(
         userIds: $userIds
         ethAddresses: $ethAddresses
     ) {
-        items {
-            ...Wallet
-        }
-        cursor {
-            ...PaginationCursor
-        }
+        ...Wallet
     }
 }


### PR DESCRIPTION
- Fixed result name in `GetWallets` query template
- Fixed result type of `GetWallets` query template to no longer be paginated