### PR TITLE
[SDK 213] Changed asset ID format argument name in `Transaction` fragment

### DIFF
--- a/enjin/schemas/shared/fragment/Transaction.gql
+++ b/enjin/schemas/shared/fragment/Transaction.gql
@@ -1,6 +1,6 @@
 #namespace enjin.sdk.shared.Transaction
 
-#arg assetIdFormat AssetIdFormat
+#arg transactionAssetIdFormat AssetIdFormat
 #arg withMeta Boolean false
 #arg withBlockchainData Boolean false
 #arg withEncodedData Boolean false
@@ -64,7 +64,7 @@ fragment Transaction on Transaction {
         uuid
     }
     asset @include(if: $withAssetData) {
-        id(format: $assetIdFormat)
+        id(format: $transactionAssetIdFormat)
     }
     wallet @include(if: $withTransactionWalletAddress) {
         ethAddress


### PR DESCRIPTION
Changed argument name in `Transaction` fragment from `assetIdFormat` to `transactionAssetIdFormat`